### PR TITLE
adding LED field, and related constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,19 @@ type State struct {
 	Red      uint8         // Red value 0-255
 	Green    uint8         // Green value 0-255
 	Blue     uint8         // Blue value 0-255
-	Normal   uint8         // Normal value 0-255
+	LED      uint8         // which LED to address (0=all, 1=1st LED, 2=2nd LED)
 	FadeTime time.Duration // Fadetime to state
 	Duration time.Duration // Duration of state after FadeTime
 }
 ```
 
 State is a Blink(1) light state
+
+```
+const (
+	LEDAll uint8 = iota
+	LED1
+	LED2
+)
+```
+LED helper constants, used to target specific LED's on the sides of Blink(1).

--- a/blink1.go
+++ b/blink1.go
@@ -62,7 +62,7 @@ func (b *Device) Close() {
 // SetState sets the blink(1) to a specific state
 func (b *Device) SetState(state State) (err error) {
 	b.CurrentState = state
-	bytesWritten := fadeToRgbBlink1(b, state.FadeTime, state.Red, state.Green, state.Blue, state.Normal)
+	bytesWritten := fadeToRgbBlink1(b, state.FadeTime, state.Red, state.Green, state.Blue, state.LED)
 	if bytesWritten <= 0 {
 		err = errors.New("Unable to write to blink(1)")
 	}

--- a/comms.go
+++ b/comms.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hink/go-blink1/libusb"
 )
 
-func fadeToRgbBlink1(device *Device, fadeTime time.Duration, red, green, blue, normal uint8) (bytesWritten int) {
-	bytesWritten = libusb.SendBlink1Command(device.Device, toMs(fadeTime), red, blue, green, normal)
+func fadeToRgbBlink1(device *Device, fadeTime time.Duration, red, green, blue, led uint8) (bytesWritten int) {
+	bytesWritten = libusb.SendBlink1Command(device.Device, toMs(fadeTime), red, blue, green, led)
 	return
 }

--- a/libusb/blink1.go
+++ b/libusb/blink1.go
@@ -12,11 +12,11 @@ const (
 	USB_HID_REPORT_TYPE_FEATURE = 3
 )
 
-func SendBlink1Command(device *Device, fadeTime int, red, blue, green, normal uint8) int {
+func SendBlink1Command(device *Device, fadeTime int, red, blue, green, led uint8) int {
 	dms := fadeTime / 10
 
 	data := []byte{
-		'0', 'c', byte(red), byte(green), byte(blue), byte(dms >> 8), byte(dms % 127), byte(normal),
+		'0', 'c', byte(red), byte(green), byte(blue), byte(dms >> 8), byte(dms % 127), byte(led),
 	}
 
 	//reportID := data[1]

--- a/pattern.go
+++ b/pattern.go
@@ -14,10 +14,17 @@ type State struct {
 	Red      uint8         // Red value 0-255
 	Green    uint8         // Green value 0-255
 	Blue     uint8         // Blue value 0-255
-	Normal   uint8         // Normal value 0-255
+	LED      uint8         // which LED to address (0=all, 1=1st LED, 2=2nd LED)
 	FadeTime time.Duration // Fadetime to state
 	Duration time.Duration // Duration of state after FadeTime
 }
 
 // OffState helper
 var OffState = State{Duration: time.Duration(10) * time.Millisecond}
+
+// LED helper constants, used to target specific LED's on the sides of Blink(1).
+const (
+	LEDAll uint8 = iota
+	LED1
+	LED2
+)


### PR DESCRIPTION
Hey, thanks for this library, it's been a breeze to use!

This PR is to clarify one `State` field that I've been using, which targets specific sides of the blink(1). It was called `Normal`, but I've renamed it to `LED`. I've updated the documentation to reflect the new field name, and added constants for each side (+all) of the blink.

Here's the blink documentation this is all based off of:

https://github.com/todbot/blink1/blob/master/commandline/blink1-lib.h#L147