### PR TITLE
sends correct reportId, fixes mk3 issue

### DIFF
--- a/libusb/blink1.go
+++ b/libusb/blink1.go
@@ -16,15 +16,15 @@ func SendBlink1Command(device *Device, fadeTime int, red, blue, green, led uint8
 	dms := fadeTime / 10
 
 	data := []byte{
-		'0', 'c', byte(red), byte(green), byte(blue), byte(dms >> 8), byte(dms % 127), byte(led),
+		1, 'c', byte(red), byte(green), byte(blue), byte(dms >> 8), byte(dms % 127), byte(led), 0,
 	}
 
-	//reportID := data[1]
+	reportID := data[0]
 
 	return int(C.usb_control_msg(device.handle,
 		C.int(USB_TYPE_CLASS|C.USB_RECIP_INTERFACE|C.USB_ENDPOINT_OUT),
 		C.int(USBRQ_HID_SET_REPORT),
-		C.int(USB_HID_REPORT_TYPE_FEATURE<<8|('c'&0xff)),
+		C.int(USB_HID_REPORT_TYPE_FEATURE<<8 | int(reportID)),
 		C.int(0),
 		(*C.char)(unsafe.Pointer(&data[0])),
 		C.int(len(data)),


### PR DESCRIPTION
The byte array and `usb_control_msg()` arguments in `libusb/blink1.go` were incorrect, but happened to work with blink(1) mk1 and mk2 devices as they did not check the reportId. Since blink(1) mk3 devices is more strict (since it supports two reportIds), mk3 devices were failing. 

To fix this, three changes were made:
* In libusb, the first byte of the byte array is the reportId.  It was set to `0x00`. For blink(1)s, the reportId should be `0x01`
* Additionally, the blink(1) report length is 8 bytes, and for libusb, this means the `data` byte array should be 9 bytes long. 
* In  `usb_control_msg()` the fourth argument is `wVvalue`, which is a logical OR of the reportId and the HID_REPORT_TYPE_FEATURE constant.  This PR sets reportId correctly for wValue.

This change has been verified to work for both blink(1) mk2 and mk3 devices on MacOS 10.15.6.